### PR TITLE
Fixing a bug in the locator

### DIFF
--- a/includes/bibdata_info.php
+++ b/includes/bibdata_info.php
@@ -40,7 +40,7 @@ if ($id > 0){
 		$this_item->display = '';
 		$this_item->status = implode(",",$bibdata_array->f[$i]->items[0]->status);
 		$this_item->tmp_location = $bibdata_array->f[$i]->items[0]->temp_location;
-		array_push($f_array, $this_item);
+		array_push($f_array, clone $this_item);
 	}
 
 }

--- a/includes/bibdata_info.php
+++ b/includes/bibdata_info.php
@@ -30,19 +30,23 @@ if ($id > 0){
 
 	$bibdata_items_url = "https://bibdata.princeton.edu/bibliographic/" . $id . "/items";
 	$json = file_get_contents($bibdata_items_url);
-	$bibdata_array = json_decode($json);
+	if ($json) {
+		$bibdata_array = json_decode($json);
 
-	$copies = count($bibdata_array->f);
-	for ($i = 0; $i < $copies; $i++) {
-		$this_item->location = $bibdata_array->f[$i]->items[0]->perm_location;
-		$this_item->call = $bibdata_array->f[$i]->sortable_call_number;
-		$this_item->call_display = $bibdata_array->f[$i]->call_number;
-		$this_item->display = '';
-		$this_item->status = implode(",",$bibdata_array->f[$i]->items[0]->status);
-		$this_item->tmp_location = $bibdata_array->f[$i]->items[0]->temp_location;
-		array_push($f_array, clone $this_item);
+		$copies = count($bibdata_array->f);
+		for ($i = 0; $i < $copies; $i++) {
+			$this_item->location = $bibdata_array->f[$i]->items[0]->perm_location;
+			$this_item->call = $bibdata_array->f[$i]->sortable_call_number;
+			$this_item->call_display = $bibdata_array->f[$i]->call_number;
+			$this_item->display = '';
+			$this_item->status = implode(",",$bibdata_array->f[$i]->items[0]->status);
+			$this_item->tmp_location = $bibdata_array->f[$i]->items[0]->temp_location;
+			array_push($f_array, clone $this_item);
+		}
+	
+	} else {
+		$f_array[0]->tmp_location= $loc;
 	}
-
 }
 
 ?>


### PR DESCRIPTION
Adding a clone so that the array instance does not get overridden with the next iteration of the loop
Also adds error handling so that  when the items do not exists we just assume any location sent to us is the current temporary location. refs #26 